### PR TITLE
Do not let nozzle cool down too much

### DIFF
--- a/Klipper_cfg/Prusa_Universal_Config_Revised/Macros/start_print.cfg
+++ b/Klipper_cfg/Prusa_Universal_Config_Revised/Macros/start_print.cfg
@@ -36,7 +36,8 @@ gcode:
     M140 S{BED_TEMP}
     # set extruder temp to 170°C to avoid filament dripping
     {% if printer.extruder.temperature|int > 170 %}
-        M117 Nozzle temp +170
+        M117 Nozzle temp +170 - cooling
+		M104 S170
     {% else %}
         M117 Preheating to 170
         M104 S170


### PR DESCRIPTION
If nozzle temp is above 170°C it will be cooled down and heated up again to 170°C.
This patch will cool down the nozzle to 170°C